### PR TITLE
HEAD should be Head in URL

### DIFF
--- a/src/Console/Command/Download.php
+++ b/src/Console/Command/Download.php
@@ -107,7 +107,7 @@ class Download extends Command
                 $this->progressBar = new ProgressBar($output, 100);
                 $output->writeln('<info> Download ' . $lang . ' start</info>');
                 $this->progressBar->start();
-                $client->request('GET', '/var/' . $branch . '/source_' . $lang . '.csv', ['sink' => DOWNLOADS_DIR . DIRECTORY_SEPARATOR . $branch . DIRECTORY_SEPARATOR . $lang . '.csv']);
+                $client->request('GET', '/var/' . ucwords(strtolower($branch)) . '/source_' . $lang . '.csv', ['sink' => DOWNLOADS_DIR . DIRECTORY_SEPARATOR . $branch . DIRECTORY_SEPARATOR . $lang . '.csv']);
                 $this->progressBar->finish();
                 $output->writeln('<info></info>');
                 $output->writeln('<info> Download ' . $lang . ' completed</info>');


### PR DESCRIPTION
fix `Client error: `GET http://107.170.242.99/var/HEAD/source_ar_SA.csv` resulted in a `404 Not Found` response:` error while download

should be http://107.170.242.99/var/Head/source_ar_SA.csv